### PR TITLE
v5.0.0 compatible with PuppeteerSharp >= 19.0.2 and tested

### DIFF
--- a/PuppeteerSharp.Dom.Tests/ElementHandleTests/CssStyleTests.cs
+++ b/PuppeteerSharp.Dom.Tests/ElementHandleTests/CssStyleTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Threading.Tasks;
 using PuppeteerSharp.Dom.Tests.Attributes;
 using Xunit.Abstractions;
@@ -96,7 +97,11 @@ namespace PuppeteerSharp.Dom.Tests.ElementHandleTests
 
             var actual = await style.GetPropertyValueAsync<object>("z-index");
 
-            Assert.Equal(expected, actual);
+            Assert.IsType<JsonElement>(actual);
+
+            var actualJE = (JsonElement)actual;
+            Assert.Equal(JsonValueKind.String, actualJE.ValueKind);
+            Assert.Equal(expected, actualJE.GetString());
         }
 
         [PuppeteerDomFact]

--- a/PuppeteerSharp.Dom.Tests/PuppeteerBaseTest.cs
+++ b/PuppeteerSharp.Dom.Tests/PuppeteerBaseTest.cs
@@ -1,6 +1,6 @@
-using Newtonsoft.Json.Linq;
 using PuppeteerSharp.Dom.TestServer;
 using System.IO;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
 
@@ -32,9 +32,9 @@ namespace PuppeteerSharp.Dom.Tests
             HttpsServer.Reset();
         }
 
-        protected static Task<JToken> WaitEvent(CDPSession emitter, string eventName)
+        protected static Task<JsonElement?> WaitEvent(CDPSession emitter, string eventName)
         {
-            var completion = new TaskCompletionSource<JToken>();
+            var completion = new TaskCompletionSource<JsonElement?>();
             void handler(object sender, MessageEventArgs e)
             {
                 if (e.MessageID != eventName)

--- a/PuppeteerSharp.Dom.Tests/PuppeteerSharp.Dom.Tests.csproj
+++ b/PuppeteerSharp.Dom.Tests/PuppeteerSharp.Dom.Tests.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-		<PackageReference Include="PuppeteerSharp" Version="18.0.3" />
+		<PackageReference Include="PuppeteerSharp" Version="19.0.2" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/PuppeteerSharp.Dom/AsyncDomExtensions.cs
+++ b/PuppeteerSharp.Dom/AsyncDomExtensions.cs
@@ -164,7 +164,7 @@ namespace PuppeteerSharp.Dom
 
             var result = await func(input).ConfigureAwait(false);
 
-            if (dispose)
+            if (dispose && input != null)
             {
                 await input.DisposeAsync().ConfigureAwait(false);
             }

--- a/PuppeteerSharp.Dom/DomHandle.cs
+++ b/PuppeteerSharp.Dom/DomHandle.cs
@@ -220,7 +220,7 @@ namespace PuppeteerSharp.Dom
         public static T ParseJSValueTo<T>(JsonElement? value)
         {
             var returnType = typeof(T);
-            if (returnType == typeof(object) || returnType == value.GetType())
+            if (returnType == typeof(object) || returnType == typeof(JsonElement?))
             {
                 return (T)(object)value;
             }
@@ -242,7 +242,7 @@ namespace PuppeteerSharp.Dom
             }
             else if (returnType == typeof(string))
             {
-                return (T)(object)value.Value.GetString();
+                return (T)(object)value.ToString();
             }
             else if (returnType.IsEnum)
             {

--- a/PuppeteerSharp.Dom/DomHandle.cs
+++ b/PuppeteerSharp.Dom/DomHandle.cs
@@ -180,7 +180,7 @@ namespace PuppeteerSharp.Dom
 
         async Task<T> IJSHandle.EvaluateFunctionAsync<T>(string script, params object[] args)
         {
-            var result = await Handle.EvaluateFunctionAsync<JsonElement?>(script, args).ConfigureAwait(false);;
+            var result = await Handle.EvaluateFunctionAsync<JsonElement?>(script, args).ConfigureAwait(false);
             return ParseJSValueTo<T>(result);
         }
 

--- a/PuppeteerSharp.Dom/DomHandle.cs
+++ b/PuppeteerSharp.Dom/DomHandle.cs
@@ -180,7 +180,7 @@ namespace PuppeteerSharp.Dom
 
         async Task<T> IJSHandle.EvaluateFunctionAsync<T>(string script, params object[] args)
         {
-            var result = await Handle.EvaluateFunctionAsync<JsonElement?>(script, args);
+            var result = await Handle.EvaluateFunctionAsync<JsonElement?>(script, args).ConfigureAwait(false);;
             return ParseJSValueTo<T>(result);
         }
 

--- a/PuppeteerSharp.Dom/DomHandle.cs
+++ b/PuppeteerSharp.Dom/DomHandle.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using PuppeteerSharp.Cdp.Messaging;
 
 namespace PuppeteerSharp.Dom
@@ -183,9 +183,9 @@ namespace PuppeteerSharp.Dom
                 .ToArray();
         }
 
-        Task<JToken> IJSHandle.EvaluateFunctionAsync(string script, params object[] args)
+        Task<JsonElement?> IJSHandle.EvaluateFunctionAsync(string script, params object[] args)
         {
-            return Handle.EvaluateFunctionAsync<JToken>(script, args);
+            return Handle.EvaluateFunctionAsync<JsonElement?>(script, args);
         }
 
         Task<T> IJSHandle.EvaluateFunctionAsync<T>(string script, params object[] args)

--- a/PuppeteerSharp.Dom/PuppeteerSharp.Dom.CodeGen.Partial.cs
+++ b/PuppeteerSharp.Dom/PuppeteerSharp.Dom.CodeGen.Partial.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using PuppeteerSharp.Input;
 
 namespace PuppeteerSharp.Dom
 {

--- a/PuppeteerSharp.Dom/PuppeteerSharp.Dom.CodeGen.Partial.cs
+++ b/PuppeteerSharp.Dom/PuppeteerSharp.Dom.CodeGen.Partial.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using PuppeteerSharp.Input;
 
 namespace PuppeteerSharp.Dom
 {
@@ -637,10 +638,15 @@ namespace PuppeteerSharp.Dom
         public async Task<T> GetAttributeAsync<T>(string attribute)
         {
             var attr = await Handle.EvaluateFunctionHandleAsync("(element, attr) => element.getAttribute(attr)", attribute).ConfigureAwait(false);
-
-            var val = await attr.JsonValueAsync<T>().ConfigureAwait(false);
-
-            return val;
+            if (attr != null && attr.RemoteObject != null)
+            {
+                return ParseJSValueTo<T>(attr.RemoteObject.Value);
+            }
+            if (Nullable.GetUnderlyingType(typeof(T)) != null || typeof(T).IsClass)
+            {
+                return (T)(object)null!;
+            }
+            throw new InvalidOperationException($"Unable to parse null value to {typeof(T)}.");
         }
 
         /// <summary>

--- a/PuppeteerSharp.Dom/PuppeteerSharp.Dom.csproj
+++ b/PuppeteerSharp.Dom/PuppeteerSharp.Dom.csproj
@@ -22,8 +22,8 @@
     </Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageId>PuppeteerSharp.Dom</PackageId>
-    <PackageReleaseNotes>Upgrade to PuppeteerSharp 18.0</PackageReleaseNotes>
-    <VersionPrefix>4.0.0</VersionPrefix>
+    <PackageReleaseNotes>Upgrade to PuppeteerSharp 19.0</PackageReleaseNotes>
+    <VersionPrefix>5.0.0</VersionPrefix>
     <!--<VersionSuffix>preview01</VersionSuffix>-->
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
@@ -33,11 +33,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="PuppeteerSharp" Version="18.0.3" />
+    <PackageReference Include="PuppeteerSharp" Version="19.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ PuppeteerSharp.Dom is an extension of [puppeteer-sharp by Darío Kondratiuk](htt
 # Prerequisites
 
  * .Net Standard 2.0
- * [PuppeteerSharp](https://www.nuget.org/packages/PuppeteerSharp/) 7.0 or greater
+ * [PuppeteerSharp](https://www.nuget.org/packages/PuppeteerSharp/) 19.0.2 or greater
 
 # Questions and Support
 
@@ -133,5 +133,22 @@ await foreach (var row in tableRowsHtmlCollection)
     }
 }
 ```
+
+# Notes
+
+## Upgrade to PuppeteerSharp.Dom 5.0.0
+
+After transition of **PuppeteerSharp** from `Newtonsoft.Json` to `System.Text.Json` in version **19.0.0** there was quite some changes so this version is no longer compatible with **PuppeterSharp** lower than **19.0.0**
+
+You may have to make changes to your code after updating to newer version
+
+## Values parsing
+
+**PuppeteerSharp** considers variable types from within JavaScript when requesting typed values on pages.
+
+**PuppeteerSharp.Dom** however allow you to obtain variables with desired data types as long as they are accurate and will throw if there is error parsing data
+
+That makes sense for strongly typed language like C# to require correct data types from evaluating but complicates interaction with DOM so is simplified
+
 <sup><a href='/PuppeteerSharp.Dom.Tests/QuerySelectorTests/PageContextQuerySelectorTests.cs#L19-L127' title='Snippet source file'>snippet source</a> | <a href='#snippet-queryselector' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/README.md
+++ b/README.md
@@ -134,15 +134,7 @@ await foreach (var row in tableRowsHtmlCollection)
 }
 ```
 
-# Notes
-
-## Upgrade to PuppeteerSharp.Dom 5.0.0
-
-After transition of **PuppeteerSharp** from `Newtonsoft.Json` to `System.Text.Json` in version **19.0.0** there was quite some changes so this version is no longer compatible with **PuppeterSharp** lower than **19.0.0**
-
-You may have to make changes to your code after updating to newer version
-
-## Values parsing
+### Be aware
 
 **PuppeteerSharp** considers variable types from within JavaScript when requesting typed values on pages.
 


### PR DESCRIPTION
* Bump dependencies accordinng to PuppeteerSharp

PuppeteerSharp => 19.0.0 removed Newtonsoft.Json dependency

* Update and fix

* Bump PuppeteerSharp.Dom version

* Update tests to work with PuppeteerSharp>=19.0.2

Update tests to use System.Text.Json

* Add DomHandle.ParseJSValueTo

* Values parsing in DomHandle.Evaluate and CodeGen.Partial Element.GetAttributeAsync

PuppeteerSharp use types of variables from JS (maybe due to transfer from Newtonsoft.Json to System.Text.Json) so it's not working and actually it make sense since C# is stronly typed

Try to parse evaluation result to requested generic type

Use ParseJSValueTo to parse evaluation result

* Update README.md