### PR TITLE
Little fixes

### DIFF
--- a/PuppeteerSharp.Dom/HtmlInputElement.cs
+++ b/PuppeteerSharp.Dom/HtmlInputElement.cs
@@ -90,7 +90,7 @@ namespace PuppeteerSharp.Dom
         /// </summary>
         /// <param name="start">start index</param>
         /// <param name="end">end index</param>
-        /// <param name="selectionDirection ">indicating the direction in which the selection is considered to have been performed.</param>
+        /// <param name="selectionDirection">indicating the direction in which the selection is considered to have been performed.</param>
         /// <returns>A Task that when awaited sets the start and end positions of the current text selection</returns>
         public Task SetSelectionRangeAsync(int start, int end, HtmlElementSelectionDirectionType? selectionDirection = null)
         {

--- a/PuppeteerSharp.Dom/HtmlTextAreaElement.cs
+++ b/PuppeteerSharp.Dom/HtmlTextAreaElement.cs
@@ -64,7 +64,7 @@ namespace PuppeteerSharp.Dom
         /// </summary>
         /// <param name="start">start index</param>
         /// <param name="end">end index</param>
-        /// <param name="selectionDirection ">indicating the direction in which the selection is considered to have been performed.</param>
+        /// <param name="selectionDirection">indicating the direction in which the selection is considered to have been performed.</param>
         /// <returns>A Task that when awaited sets the start and end positions of the current text selection</returns>
         public Task SetSelectionRangeAsync(int start, int end, HtmlElementSelectionDirectionType? selectionDirection = null)
         {

--- a/PuppeteerSharp.Dom/PuppeteerSharp.Dom.csproj
+++ b/PuppeteerSharp.Dom/PuppeteerSharp.Dom.csproj
@@ -23,7 +23,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageId>PuppeteerSharp.Dom</PackageId>
     <PackageReleaseNotes>Upgrade to PuppeteerSharp 19.0</PackageReleaseNotes>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.0.40</VersionPrefix>
     <!--<VersionSuffix>preview01</VersionSuffix>-->
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
* Fix doc typo
* Fix **VersionPrefix** in PuppeteerSharp.Dom .csproj
When having nuget dependency and referencing local fork reference in main and dependant projects during compilation you get error regarding assembly version mismatch (_Rider 2024.3_)